### PR TITLE
Supports Windows via sprintf proxy

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -1,0 +1,16 @@
+name: CI (Windows)
+on:
+  workflow_call:
+jobs:
+  build:
+    name: Windows
+    runs-on: windows-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v5
+      with:
+        submodules: recursive
+    - name: Update Rust
+      run: rustup update stable
+    - name: Run tests
+      run: cargo test -r

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,3 +26,7 @@ jobs:
     name: Build
     uses: ./.github/workflows/ci-mac.yml
     needs: prebuild
+  build-windows:
+    name: Build
+    uses: ./.github/workflows/ci-windows.yml
+    needs: prebuild

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,5 +26,8 @@ criterion = { version = "0.7.0", features = ["html_reports"] }
 mlua = { version = "0.11.3", features = ["lua54", "vendored"] }
 tokio = { version = "1.47.1", features = ["rt", "time"] }
 
+[target.'cfg(windows)'.build-dependencies]
+cc = "1.2.35"
+
 [profile.bench]
 debug = "full"

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Tsuki
 [![Crates.io Version](https://img.shields.io/crates/v/tsuki)](https://crates.io/crates/tsuki)
 
-Tsuki is a port of Lua 5.4 to Rust. This is porting, not binding; which mean all code are Rust and can be using without C compiler. The initial works was done by [C2Rust](https://github.com/immunant/c2rust). Note that this port was done **without** compatibility with the previous version. You can see a list of the differences [here](https://www.lua.org/manual/5.4/manual.html#8).
+Tsuki is a port of Lua 5.4 to Rust. This is porting, not binding; which mean all code are Rust and can be using without C compiler[^1]. The initial works was done by [C2Rust](https://github.com/immunant/c2rust). Note that this port was done **without** compatibility with the previous version. You can see a list of the differences [here](https://www.lua.org/manual/5.4/manual.html#8).
 
 > [!IMPORTANT]
 > Tsuki does not support multi-threading and no plan to support this at the moment.
 
 ## Safety
 
-All public API of Tsuki should provide 100% safety as long as you don't use unsafe API.
+All public API of Tsuki should provide 100% safety as long as you don't use unsafe API incorrectly.
 
 ## Features
 
@@ -59,10 +59,11 @@ All public API of Tsuki should provide 100% safety as long as you don't use unsa
 
 ## Roadmap
 
-- Support Windows.
 - Remove libc.
 - JIT using Cranelift.
 
 ## License
 
 MIT
+
+[^1]: On Windows, a proxy to `sprintf` written in C++ is required at the moment. This proxy will be removed when we replace `sprintf` calls with Rust equivalent.

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,12 @@
+fn main() {
+    #[cfg(windows)]
+    build_proxy();
+}
+
+#[cfg(windows)]
+fn build_proxy() {
+    cc::Build::new()
+        .cpp(true)
+        .file("windows.cpp")
+        .compile("tsukiproxy");
+}

--- a/src/builtin/string.rs
+++ b/src/builtin/string.rs
@@ -1,9 +1,9 @@
+use crate::libc::snprintf;
 use crate::{Args, Context, Ret, Type};
 use alloc::boxed::Box;
 use alloc::format;
 use alloc::string::String;
 use alloc::vec::Vec;
-use libc::snprintf;
 
 /// Implementation of [string.format](https://www.lua.org/manual/5.4/manual.html#pdf-string.format).
 pub fn format<D>(cx: Context<D, Args>) -> Result<Context<D, Ret>, Box<dyn core::error::Error>> {

--- a/src/libc/mod.rs
+++ b/src/libc/mod.rs
@@ -3,5 +3,5 @@ pub use libc::*;
 #[cfg(windows)]
 unsafe extern "C-unwind" {
     #[link_name = "tsuki_snprintf"]
-    fn snprintf(buffer: *mut c_char, count: usize, format: *const c_char, ...) -> c_int;
+    pub fn snprintf(buffer: *mut c_char, count: usize, format: *const c_char, ...) -> c_int;
 }

--- a/src/libc/mod.rs
+++ b/src/libc/mod.rs
@@ -1,0 +1,7 @@
+pub use libc::*;
+
+#[cfg(windows)]
+unsafe extern "C-unwind" {
+    #[link_name = "tsuki_snprintf"]
+    fn snprintf(buffer: *mut c_char, count: usize, format: *const c_char, ...) -> c_int;
+}

--- a/src/lobject.rs
+++ b/src/lobject.rs
@@ -8,6 +8,7 @@
 
 use crate::gc::Object;
 use crate::lctype::luai_ctype_;
+use crate::libc::snprintf;
 use crate::lmem::luaM_free_;
 use crate::ltm::{TM_ADD, TMS, luaT_trybinTM};
 use crate::value::UnsafeValue;
@@ -15,7 +16,7 @@ use crate::vm::{F2Ieq, luaV_idiv, luaV_mod, luaV_modf, luaV_shiftl, luaV_tointeg
 use crate::{Args, ArithError, ChunkInfo, Context, Lua, Ops, Ret, Str, Thread};
 use alloc::boxed::Box;
 use core::cell::{Cell, UnsafeCell};
-use libc::{c_char, c_int, sprintf, strpbrk, strspn, strtod};
+use libc::{c_char, c_int, strpbrk, strspn, strtod};
 use libm::{floor, pow};
 
 #[repr(C)]
@@ -771,14 +772,16 @@ pub unsafe fn luaO_utf8esc(buff: *mut c_char, mut x: libc::c_ulong) -> c_int {
 
 unsafe fn tostringbuff<D>(obj: *const UnsafeValue<D>, buff: *mut c_char) -> c_int {
     if (*obj).tt_ == 3 | 0 << 4 {
-        sprintf(
+        snprintf(
             buff,
+            44,
             b"%lld\0" as *const u8 as *const c_char,
             (*obj).value_.i,
         )
     } else {
-        let mut len = sprintf(
+        let mut len = snprintf(
             buff,
+            44,
             b"%.14g\0" as *const u8 as *const c_char,
             (*obj).value_.n,
         );

--- a/windows.cpp
+++ b/windows.cpp
@@ -1,0 +1,14 @@
+#include <stdarg.h>
+#include <stdio.h>
+
+extern "C" int tsuki_snprintf(char *buffer, size_t count, const char *format, ...)
+{
+    va_list args;
+    int ret;
+
+    va_start(args, format);
+    ret = vsnprintf(buffer, count, format, args);
+    va_end(args);
+
+    return ret;
+}


### PR DESCRIPTION
This C++ proxy will be an interim solution until we replaces `sprintf` calls with Rust equivalent.